### PR TITLE
Enable clusterConstraints in `schema.yaml`

### DIFF
--- a/schema.yaml
+++ b/schema.yaml
@@ -9,21 +9,22 @@ x-google-marketplace:
   managedUpdates:
     kalmSupported: false
   # clusterConstraints:
-  #   resources:
-  #   - replicas: 2  # Entry for non-GPU resources
-  #     requests:
-  #       cpu: 28000m  # Increased from 6000m to accommodate MDI's 16 cores + other services
-  #       memory: 80Gi  # Increased from 24Gi to accommodate MDI's 64Gi + other services
-  #   - requests:  # Entry for GPU resources
-  #       gpu:
-  #         nvidia.com/gpu:
-  #           limits: 1
-  #           platforms:
-  #           - nvidia-tesla-t4
-  #           - nvidia-tesla-v100
-  #           - nvidia-tesla-p100
-  #           - nvidia-tesla-p4
-  #           - nvidia-tesla-a100
+  clusterConstraints:
+    resources:
+    - replicas: 2  # Entry for non-GPU resources
+      requests:
+        cpu: 28000m  # Increased from 6000m to accommodate MDI's 16 cores + other services
+        memory: 80Gi  # Increased from 24Gi to accommodate MDI's 64Gi + other services
+    - requests:  # Entry for GPU resources
+        gpu:
+          nvidia.com/gpu:
+            limits: 1
+            platforms:
+            - nvidia-tesla-t4
+            - nvidia-tesla-v100
+            - nvidia-tesla-p100
+            - nvidia-tesla-p4
+            - nvidia-tesla-a100
   images:
     aktus-inference:
       properties:


### PR DESCRIPTION
### Context and Motivation

**Note**: This PR is based on PR #15 and will be rebased onto `main` after that PR is merged. 

The existing `schema.yaml` for our Google Cloud Marketplace integration had the `clusterConstraints` section commented out. As a result, deployments were using default resource requests, which proved insufficient for the MDI inference service’s requirements. To ensure our solution is scheduled on nodes with adequate CPU, memory, and (optionally) GPU capacity, we need to enable and configure `clusterConstraints`. This change guarantees:

* Non-GPU workloads run on nodes with at least 28 vCPU cores and 80 GiB of RAM (to accommodate MDI’s 16-core/64 GiB footprint plus overhead).
* GPU workloads request one GPU and advertise compatibility with desired NVIDIA platforms (T4, V100, P100, P4, A100).

### Summary of Changes

* Uncommented the `clusterConstraints` block under `x-google-marketplace`.

  ```yaml
  clusterConstraints:
    resources:
    - replicas: 2
      requests:
        cpu: 28000m
        memory: 80Gi
    - requests:
        gpu:
          nvidia.com/gpu:
            limits: 1
            platforms:
            - nvidia-tesla-t4
            - nvidia-tesla-v100
            - nvidia-tesla-p100
            - nvidia-tesla-p4
            - nvidia-tesla-a100
  ```

  1. **Replicas: 2**
     Ensures that, for non-GPU workloads, two pod replicas are scheduled across the cluster for high availability.
  2. **Resource Requests (Non-GPU)**

     * `cpu: 28000m` (28 vCPUs) — raised from 6000m (6 vCPUs) to meet MDI’s requirement of 16 vCPUs + ancillary services.
     * `memory: 80Gi` — raised from 24 GiB to satisfy MDI’s 64 GiB footprint plus overhead (logging, sidecars, etc.).
  3. **Resource Requests (GPU)**

     * Requests exactly **1 GPU** per pod.
     * The `platforms` list restricts GPU node selection to T4, V100, P100, P4, or A100 series cards, ensuring compatibility with our inference workloads.

### Testing

* Schema was validation locally. 
