### PR TITLE
Upgrade version 1.0.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY marketplace-annotations.yaml /data/marketplace-annotations.yaml
 LABEL com.googleapis.cloudmarketplace.product.service.name="services/aktus-ai-platform.endpoints.aktus-ai-platform-public.cloud.goog"
 LABEL com.google.cloudmarketplace.service.endpoint="services/aktus-ai-platform.endpoints.aktus-ai-platform-public.cloud.goog"
 LABEL com.google.cloud.marketplace.service.endpoint="services/aktus-ai-platform.endpoints.aktus-ai-platform-public.cloud.goog"
-LABEL com.google.cloud.marketplace.solution-version="1.0.3"
+LABEL com.google.cloud.marketplace.solution-version="1.0.8"
 LABEL com.google.cloud.marketplace.partner-id="YL8mwhgO2T"
 LABEL com.google.cloud.marketplace.solution-id="aktus-ai-platform"
 LABEL maintainer="Aktus AI <support@aktus.ai>"

--- a/README.md
+++ b/README.md
@@ -98,6 +98,6 @@ After successful deployment:
 
 **Ready to deploy your AI platform?** 🚀
 
-*Version 1.0.3 | Last Updated: May 2025*
+*Version 1.0.8 | Last Updated: May 2025*
 
 </div>

--- a/build-and-annotate.sh
+++ b/build-and-annotate.sh
@@ -71,7 +71,7 @@ export DOCKER_BUILDKIT=1
 echo "Pulling base image..."
 docker pull gcr.io/cloud-marketplace-tools/k8s/deployer_helm/onbuild:latest || { echo "Failed to pull base image"; exit 1; }
 
-# Build and push the image with the version tag (1.0.3)
+# Build and push the image with the version tag (1.0.8)
 echo "Building and pushing version-tagged image..."
 docker buildx build --platform linux/amd64 \
     --no-cache \

--- a/chart/aktus-ai-platform/Chart.yaml
+++ b/chart/aktus-ai-platform/Chart.yaml
@@ -2,8 +2,8 @@
 apiVersion: v2
 name: aktus-platform
 description: Umbrella chart for Aktus AI platform
-appVersion: "1.0.3"
-version: 1.0.3
+appVersion: "1.0.8"
+version: 1.0.8
 type: application
 home: https://aktus.ai
 sources:
@@ -17,58 +17,58 @@ dependencies:
 
   # Databases and Message Queues (Level 1)
   - name: aktus-postgres-service
-    version: "1.0.3"
+    version: "1.0.8"
     repository: "file://./charts/postgres"
     tags:
       - infrastructure
 
   - name: rabbitmq
-    version: "1.0.3"
+    version: "1.0.8"
     repository: "file://./charts/rabbitmq"
     tags:
       - infrastructure
 
   - name: redis
-    version: "1.0.3"
+    version: "1.0.8"
     repository: "file://./charts/redis"
     tags:
       - infrastructure
 
   - name: qdrant
-    version: "1.0.3"
+    version: "1.0.8"
     repository: "file://./charts/qdrant"
-    condition: qdrant-service.enabled
+    condition: enableProductionMode
     tags:
       - infrastructure
 
   # Core Services (Level 2)
   - name: aktus-database-service
-    version: "1.0.3"
+    version: "1.0.8"
     repository: "file://./charts/aktus-db-manager"
-    condition: aktus-database-service.enabled
+    condition: enableProductionMode
 
   - name: aktus-inference-service
-    version: "1.0.3"
+    version: "1.0.8"
     repository: "file://./charts/aktus-inference"
-    condition: aktus-inference-service.enabled
+    condition: enableProductionMode
 
   # Application Services (Level 3)
   - name: aktus-research-service
-    version: "1.0.3"
+    version: "1.0.8"
     repository: "file://./charts/aktus-research"
-    condition: aktus-research-service.enabled
+    condition: enableProductionMode
 
   - name: aktus-multimodal-data-ingestion-service
-    version: "1.0.3"
+    version: "1.0.8"
     repository: "file://./charts/aktus-multimodal-data-ingestion"
-    condition: aktus-multimodal-data-ingestion-service.enabled
+    condition: enableProductionMode
 
   - name: aktus-embedding-service
-    version: "1.0.3"
+    version: "1.0.8"
     repository: "file://./charts/aktus-embedding"
-    condition: aktus-embedding-service.enabled
+    condition: enableProductionMode
 
   - name: aktus-knowledge-assistant-service
-    version: "1.0.3"
+    version: "1.0.8"
     repository: "file://./charts/aktus-knowledge-assistant"
-    condition: aktus-knowledge-assistant-service.enabled
+    condition: enableProductionMode

--- a/chart/aktus-ai-platform/charts/aktus-db-manager/Chart.yaml
+++ b/chart/aktus-ai-platform/charts/aktus-db-manager/Chart.yaml
@@ -2,5 +2,5 @@
 apiVersion: v2
 name: aktus-database-service
 description: Database Manager Service for Aktus platform
-version: 1.0.3
+version: 1.0.8
 type: application

--- a/chart/aktus-ai-platform/charts/aktus-db-manager/templates/service.yaml
+++ b/chart/aktus-ai-platform/charts/aktus-db-manager/templates/service.yaml
@@ -7,7 +7,6 @@ metadata:
     cloud.google.com/load-balancer-type: "External"
 spec:
   type: LoadBalancer
-  loadBalancerIP: "{{ .Values.global.networkSettings.databaseServiceIp }}"
   ports:
     - port: 8080
       targetPort: http

--- a/chart/aktus-ai-platform/charts/aktus-db-manager/values.yaml
+++ b/chart/aktus-ai-platform/charts/aktus-db-manager/values.yaml
@@ -1,6 +1,6 @@
 # aktus-db-manager/values.yaml
 aktusDatabase:
-  image: us-docker.pkg.dev/aktus-ai-platform-public/aktus-platform-marketplace/aktus-db-manager:1.0.3
+  image: us-docker.pkg.dev/aktus-ai-platform-public/aktus-platform-marketplace/aktus-db-manager:1.0.8
   imagePullPolicy: Always
   port: 80
   resources:

--- a/chart/aktus-ai-platform/charts/aktus-embedding/Chart.yaml
+++ b/chart/aktus-ai-platform/charts/aktus-embedding/Chart.yaml
@@ -2,5 +2,5 @@
 apiVersion: v2
 name: aktus-embedding-service
 description: Embedding Service for Aktus platform
-version: 1.0.3
+version: 1.0.8
 type: application

--- a/chart/aktus-ai-platform/charts/aktus-embedding/templates/service.yaml
+++ b/chart/aktus-ai-platform/charts/aktus-embedding/templates/service.yaml
@@ -7,7 +7,6 @@ metadata:
     cloud.google.com/load-balancer-type: "External"
 spec:
   type: LoadBalancer
-  loadBalancerIP: "{{ .Values.global.networkSettings.embeddingServiceIp }}"
   ports:
     - port: 8080
       targetPort: http

--- a/chart/aktus-ai-platform/charts/aktus-inference/Chart.yaml
+++ b/chart/aktus-ai-platform/charts/aktus-inference/Chart.yaml
@@ -2,5 +2,5 @@
 apiVersion: v2
 name: aktus-inference-service
 description: Model Inference Service for Aktus platform with GCS FUSE storage
-version: 1.0.3
+version: 1.0.8
 type: application

--- a/chart/aktus-ai-platform/charts/aktus-inference/templates/deployment.yaml
+++ b/chart/aktus-ai-platform/charts/aktus-inference/templates/deployment.yaml
@@ -67,9 +67,9 @@ spec:
               value: "all"
             - name: CUDA_VISIBLE_DEVICES
               value: "0"
+            - name: USE_MINICPM_FOR_FLOWCHART
+              value: "true"
           volumeMounts:
-            - name: models-data
-              mountPath: {{ .Values.aktusInference.paths.models }}
             - name: document-upload
               mountPath: {{ .Values.aktusInference.paths.docUpload }}
             - name: doc-processing
@@ -88,13 +88,6 @@ spec:
               memory: "32Gi"
               ephemeral-storage: "5Gi"
       volumes:
-        - name: models-data
-          csi:
-            driver: gcsfuse.csi.storage.gke.io
-            readOnly: {{ .Values.aktusInference.storage.models.readOnly }}
-            volumeAttributes:
-              bucketName: {{ .Values.global.storageSettings.modelsBucketName }}
-              mountOptions: "{{ .Values.aktusInference.storage.models.mountOptions }}"
         - name: document-upload
           csi:
             driver: gcsfuse.csi.storage.gke.io

--- a/chart/aktus-ai-platform/charts/aktus-knowledge-assistant/Chart.yaml
+++ b/chart/aktus-ai-platform/charts/aktus-knowledge-assistant/Chart.yaml
@@ -3,5 +3,5 @@ apiVersion: v2
 name: aktus-knowledge-assistant-service
 description: A Helm chart for Knowledge Assistant Service
 type: application
-version: 1.0.3
-appVersion: "1.0.3"
+version: 1.0.8
+appVersion: "1.0.8"

--- a/chart/aktus-ai-platform/charts/aktus-knowledge-assistant/templates/deployment.yaml
+++ b/chart/aktus-ai-platform/charts/aktus-knowledge-assistant/templates/deployment.yaml
@@ -33,12 +33,12 @@ spec:
             - name: VITE_SOCKET_URL
               value: "ws://{{ .Values.global.networkSettings.researchServiceIp }}:8080/chat"
             - name: VITE_API_BASE_URL
-              value: "http://{{ .Values.global.networkSettings.databaseServiceIp }}:8080"
+              value: "http://{{ .Values.global.networkSettings.researchServiceIp }}:8080/db-manager"
             - name: VITE_WAITLIST_FORM_ID
               value: "c989a45ed2991b0cb7455a37ced244f0"
             - name: VITE_LEASE_API_BASE_URL
               value: "http://{{ .Values.global.networkSettings.researchServiceIp }}:8080"
             - name: VITE_API_EMBED_URL
-              value: "http://{{ .Values.global.networkSettings.embeddingServiceIp }}:8080"
+              value: "http://{{ .Values.global.networkSettings.researchServiceIp }}:8080/embeddings"
           resources:
             {{- toYaml .Values.aktusKnowledgeAssistant.resources | nindent 12 }}

--- a/chart/aktus-ai-platform/charts/aktus-knowledge-assistant/templates/service.yaml
+++ b/chart/aktus-ai-platform/charts/aktus-knowledge-assistant/templates/service.yaml
@@ -6,7 +6,6 @@ metadata:
     app: aktus-knowledge-assistant-service
 spec:
   type: LoadBalancer
-  loadBalancerIP: "{{ .Values.global.networkSettings.knowledgeAssistantIp }}"
   ports:
     - port: 8080
       targetPort: 80

--- a/chart/aktus-ai-platform/charts/aktus-multimodal-data-ingestion/Chart.yaml
+++ b/chart/aktus-ai-platform/charts/aktus-multimodal-data-ingestion/Chart.yaml
@@ -2,5 +2,5 @@
 apiVersion: v2
 name: aktus-multimodal-data-ingestion-service
 description: Multimodal Data Ingestion Service for Aktus platform
-version: 1.0.3
+version: 1.0.8
 type: application

--- a/chart/aktus-ai-platform/charts/aktus-multimodal-data-ingestion/templates/deployment.yaml
+++ b/chart/aktus-ai-platform/charts/aktus-multimodal-data-ingestion/templates/deployment.yaml
@@ -105,9 +105,9 @@ spec:
               value: "1"
             - name: VDB_GRAPHRAG_INDEXING_ENDPOINT
               value: "http://{{ .Values.aktusMdi.vectorEmbedding.host }}/vectorindex/index_graphrag"
+            - name: USE_MINICPM_FOR_FLOWCHART
+              value: "true"
           volumeMounts:
-            - name: models-data
-              mountPath: {{ .Values.aktusMdi.paths.models }}
             - name: doc-processing
               mountPath: {{ .Values.aktusMdi.paths.docProcessing }}
             - name: extracted-data
@@ -118,13 +118,6 @@ spec:
             {{- toYaml .Values.aktusMdi.resources | nindent 12 }}
       volumes:
         {{- if .Values.global.enableGCSAccess }}
-        - name: models-data
-          csi:
-            driver: gcsfuse.csi.storage.gke.io
-            readOnly: {{ .Values.aktusMdi.storage.models.readOnly }}
-            volumeAttributes:
-              bucketName: {{ .Values.global.storageSettings.modelsBucketName }}
-              mountOptions: "{{ .Values.aktusMdi.storage.models.mountOptions }}"
         - name: doc-processing
           csi:
             driver: gcsfuse.csi.storage.gke.io
@@ -147,8 +140,6 @@ spec:
               bucketName: {{ .Values.global.storageSettings.docUploadBucketName }}
               mountOptions: "{{ .Values.aktusMdi.storage.docUpload.mountOptions }}"
         {{- else }}
-        - name: models-data
-          emptyDir: {}
         - name: doc-processing
           emptyDir: {}
         - name: extracted-data

--- a/chart/aktus-ai-platform/charts/aktus-research/Chart.yaml
+++ b/chart/aktus-ai-platform/charts/aktus-research/Chart.yaml
@@ -3,5 +3,5 @@ apiVersion: v2
 name: aktus-research-service
 description: A Helm chart for Research Service
 type: application
-version: 1.0.3
-appVersion: "1.0.3"
+version: 1.0.8
+appVersion: "1.0.8"

--- a/chart/aktus-ai-platform/charts/aktus-research/templates/deployment.yaml
+++ b/chart/aktus-ai-platform/charts/aktus-research/templates/deployment.yaml
@@ -71,6 +71,10 @@ spec:
               value: abstract
             - name: LEASE_DATA_CASHFLOW_FOLDER
               value: cashflow
+            - name: VDB_ENDPOINT
+              value: http://aktus-embedding:8080
+            - name: DB_MANAGER_ENDPOINT
+              value: http://aktus-database:8080
           volumeMounts:
             - name: document-upload
               mountPath: {{ .Values.aktusResearch.paths.docUpload }}

--- a/chart/aktus-ai-platform/charts/aktus-research/values.yaml
+++ b/chart/aktus-ai-platform/charts/aktus-research/values.yaml
@@ -1,5 +1,5 @@
 aktusResearch:
-  image: us-docker.pkg.dev/aktus-ai-platform-public/aktus-platform-marketplace/aktus-research:1.0.3
+  image: us-docker.pkg.dev/aktus-ai-platform-public/aktus-platform-marketplace/aktus-research:1.0.8
   imagePullPolicy: Always
   port: 8080
   service:

--- a/chart/aktus-ai-platform/charts/postgres/Chart.yaml
+++ b/chart/aktus-ai-platform/charts/postgres/Chart.yaml
@@ -2,5 +2,5 @@
 apiVersion: v2
 name: aktus-postgres-service
 description: PostgreSQL database for Aktus platform
-version: 1.0.3
+version: 1.0.8
 type: application

--- a/chart/aktus-ai-platform/charts/qdrant/Chart.yaml
+++ b/chart/aktus-ai-platform/charts/qdrant/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: qdrant
 description: Qdrant vector search engine
-version: 1.0.3
+version: 1.0.8
 type: application 

--- a/chart/aktus-ai-platform/charts/rabbitmq/Chart.yaml
+++ b/chart/aktus-ai-platform/charts/rabbitmq/Chart.yaml
@@ -2,5 +2,5 @@
 apiVersion: v2
 name: rabbitmq
 description: RabbitMQ service for Aktus platform
-version: 1.0.3
+version: 1.0.8
 type: application

--- a/chart/aktus-ai-platform/charts/redis/Chart.yaml
+++ b/chart/aktus-ai-platform/charts/redis/Chart.yaml
@@ -2,5 +2,5 @@
 apiVersion: v2
 name: redis
 description: Redis service for Aktus platform
-version: 1.0.3
+version: 1.0.8
 type: application

--- a/chart/aktus-ai-platform/templates/NOTES.txt
+++ b/chart/aktus-ai-platform/templates/NOTES.txt
@@ -1,6 +1,6 @@
 Thank you for installing {{ .Chart.Name }}.
 
-{{- if and (index .Values "networkSettings.researchServiceIp") (index .Values "networkSettings.knowledgeAssistantIp") }}
+{{- if and (index .Values "networkSettings.researchServiceIp") }}
 
 To manually configure the static IPs for the LoadBalancer services, run the following commands:
 
@@ -8,17 +8,12 @@ To manually configure the static IPs for the LoadBalancer services, run the foll
    kubectl patch svc aktus-research -n {{ .Release.Namespace }} --type='json' \
    -p='[{"op": "replace", "path": "/spec/loadBalancerIP", "value":"{{ index .Values "networkSettings.researchServiceIp" }}"}]'
 
-2. Set up the Knowledge Assistant static IP:
-   kubectl patch svc aktus-knowledge-assistant -n {{ .Release.Namespace }} --type='json' \
-   -p='[{"op": "replace", "path": "/spec/loadBalancerIP", "value":"{{ index .Values "networkSettings.knowledgeAssistantIp" }}"}]'
-
-3. Update the Knowledge Assistant WebSocket URL:
+2. Update the Knowledge Assistant WebSocket URL:
    kubectl set env deployment/aktus-knowledge-assistant -n {{ .Release.Namespace }} \
    VITE_SOCKET_URL="ws://{{ index .Values "networkSettings.researchServiceIp" }}:8080/chat"
 
 The application services can be accessed at:
 - Research Service: http://{{ index .Values "networkSettings.researchServiceIp" }}:8080
-- Knowledge Assistant: http://{{ index .Values "networkSettings.knowledgeAssistantIp" }}:8080
 {{- else }}
 
 Your application is deployed. To access the services, find the external IPs with:

--- a/chart/aktus-ai-platform/templates/application.yaml
+++ b/chart/aktus-ai-platform/templates/application.yaml
@@ -30,26 +30,6 @@ spec:
 
       Thank you for installing the Aktus AI Platform!
 
-      ## Getting Started
-
-      1. Access the Research Service at http://{{ index .Values "global.networkSettings.researchServiceIp" }}:8080
-      2. Access the Knowledge Assistant at http://{{ index .Values "global.networkSettings.knowledgeAssistantIp" }}:8080
-      3. For the inference service, use gRPC at aktus-inference:50051 (internal)
-      
-      ## WebSocket Configuration
-      
-      The Knowledge Assistant service uses WebSocket connections to the Research Service for chat functionality.
-      Your deployment is configured to use:
-      - Research Service IP: {{ index .Values "global.networkSettings.researchServiceIp" }}
-      - Knowledge Assistant IP: {{ index .Values "global.networkSettings.knowledgeAssistantIp" }}
-      - WebSocket URL: ws://{{ index .Values "global.networkSettings.researchServiceIp" }}/chat
-      
-      ## Static IP Resources
-      
-      The deployment uses the following static IP resources:
-      - Research Service IP: {{ index .Values "global.networkSettings.researchServiceIp" }}
-      - Knowledge Assistant IP: {{ index .Values "global.networkSettings.knowledgeAssistantIp" }}
-      
       ## Components
 
       The platform consists of the following services:
@@ -71,11 +51,6 @@ spec:
       The platform uses GCS storage buckets for:
       {{- if .Values.global }}
       {{- if .Values.global.storageSettings }}
-      {{- if .Values.global.storageSettings.modelsBucketName }}
-      - Model storage: {{ .Values.global.storageSettings.modelsBucketName }}
-      {{- else }}
-      - Model storage: [Not configured]
-      {{- end }}
       {{- if .Values.global.storageSettings.docUploadBucketName }}
       - Document uploads: {{ .Values.global.storageSettings.docUploadBucketName }}
       {{- else }}

--- a/chart/aktus-ai-platform/values.yaml
+++ b/chart/aktus-ai-platform/values.yaml
@@ -1,3 +1,6 @@
+# Production Mode Configuration
+enableProductionMode: false
+
 # Enable/disable services
 rabbitmq:
   enabled: true
@@ -49,12 +52,8 @@ global:
   # Pass network settings to subcharts
   networkSettings:
     researchServiceIp: ""
-    knowledgeAssistantIp: ""
-    databaseServiceIp: ""
-    embeddingServiceIp: ""
 
   storageSettings:
-    modelsBucketName: ""
     docUploadBucketName: ""
     docProcessingBucketName: ""
     extractedDataBucketName: ""
@@ -136,10 +135,6 @@ aktus-inference-service:
         memory: "72Gi" #"32Gi"
         nvidia.com/gpu: 1
         ephemeral-storage: "5Gi"
-
-# Network configuration is now in the global section
-# networkSettings.researchServiceIp: ""
-# networkSettings.knowledgeAssistantIp: ""
 
 # Application Services
 aktus-research-service:

--- a/schema.yaml
+++ b/schema.yaml
@@ -3,63 +3,66 @@
 x-google-marketplace:
   schemaVersion: v2
   applicationApiVersion: v1beta1
-  publishedVersion: "1.0.3"
+  publishedVersion: "1.0.8"
   publishedVersionMetadata:
     releaseNote: Initial release of Aktus AI Platform.
   managedUpdates:
     kalmSupported: false
-  # clusterConstraints:
-  #   resources:
-  #   - replicas: 2  # Entry for non-GPU resources
-  #     requests:
-  #       cpu: 28000m  # Increased from 6000m to accommodate MDI's 16 cores + other services
-  #       memory: 80Gi  # Increased from 24Gi to accommodate MDI's 64Gi + other services
-  #   - requests:  # Entry for GPU resources
-  #       gpu:
-  #         nvidia.com/gpu:
-  #           limits: 1
-  #           platforms:
-  #           - nvidia-tesla-t4
-  #           - nvidia-tesla-v100
-  #           - nvidia-tesla-p100
-  #           - nvidia-tesla-p4
-  #           - nvidia-tesla-a100
+  clusterConstraints:
+    resources:
+    - replicas: 2
+      requests:
+        cpu: 28000m
+        memory: 80Gi
+    - requests:
+        gpu:
+          nvidia.com/gpu:
+            limits: 1
+            platforms:
+            - nvidia-tesla-a100
   images:
     aktus-inference:
       properties:
         aktus-inference-service.aktusInference.image:
           type: FULL
-          default: gcr.io/aktus-ai-platform-public/aktus-platform-marketplace/aktus-inference:1.0.3
+          default: gcr.io/aktus-ai-platform-public/aktus-platform-marketplace/aktus-inference:1.0.8
     aktus-multimodal-data-ingestion:
       properties:
         aktus-multimodal-data-ingestion-service.aktusMdi.image:
           type: FULL
-          default: gcr.io/aktus-ai-platform-public/aktus-platform-marketplace/multimodal-data-ingestion:1.0.3
+          default: gcr.io/aktus-ai-platform-public/aktus-platform-marketplace/multimodal-data-ingestion:1.0.8
     aktus-research:
       properties:
         aktus-research-service.aktusResearch.image:
           type: FULL
-          default: gcr.io/aktus-ai-platform-public/aktus-platform-marketplace/aktus-research:1.0.3
+          default: gcr.io/aktus-ai-platform-public/aktus-platform-marketplace/aktus-research:1.0.8
     aktus-database:
       properties:
         aktus-database-service.aktusDatabase.image:
           type: FULL
-          default: gcr.io/aktus-ai-platform-public/aktus-platform-marketplace/aktus-database:1.0.3
+          default: gcr.io/aktus-ai-platform-public/aktus-platform-marketplace/aktus-database:1.0.8
     aktus-embedding:
       properties:
         aktus-embedding-service.aktusEmbedding.image:
           type: FULL
-          default: gcr.io/aktus-ai-platform-public/aktus-platform-marketplace/aktus-embedding:1.0.3
+          default: gcr.io/aktus-ai-platform-public/aktus-platform-marketplace/aktus-embedding:1.0.8
     aktus-knowledge-assistant:
       properties:
         aktus-knowledge-assistant-service.aktusKnowledgeAssistant.image:
           type: FULL
-          default: gcr.io/aktus-ai-platform-public/aktus-platform-marketplace/aktus-knowledge-assistant:1.0.3
+          default: gcr.io/aktus-ai-platform-public/aktus-platform-marketplace/aktus-knowledge-assistant:1.0.8
 
 form:
 - widget: help
   description: >
     <div style="font-family: 'Google Sans', Arial, sans-serif; max-width: 850px; margin: 0 auto; padding: 24px; border-radius: 12px; background: #fff; box-shadow: 0 2px 10px rgba(0,0,0,0.08); color: #202124;">
+      
+      <!-- 14 Days Trial Card - Minimal & Elegant -->
+      <div style="background: linear-gradient(135deg, rgba(102, 126, 234, 0.08) 0%, rgba(118, 75, 162, 0.06) 100%); backdrop-filter: blur(10px); border: 1px solid rgba(102, 126, 234, 0.1); border-radius: 8px; padding: 16px 20px; margin-bottom: 24px; text-align: center;">
+        <div style="font-size: 20px; font-weight: 500; color: #1a73e8; margin-bottom: 4px;">14-Day Free Trial</div>
+        <div style="font-size: 13px; color: #5f6368; font-weight: 400;">Experience full platform capabilities</div>
+      </div>
+      
       <div style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); padding: 16px; border-radius: 8px; margin-bottom: 20px; text-align: center; box-shadow: 0 4px 12px rgba(102, 126, 234, 0.3);">
         <h2 style="margin: 0 0 8px 0; font-weight: 600; color: #fff; font-size: 18px;">🎥 Video Installation Guide</h2>
         <p style="margin: 0 0 12px 0; color: rgba(255,255,255,0.9); font-size: 13px;">Step-by-step video covering cluster setup, configuration, and deployment</p>
@@ -220,6 +223,7 @@ properties:
     type: string
     title: "Step 1: Application Name"
     description: "Name for your Aktus AI Platform deployment"
+    default: "aktus-ai-platform-marketplace"
     x-google-marketplace:
       type: NAME
       
@@ -266,32 +270,8 @@ properties:
     title: "Step 2: Research Service Static IP"
     description: "Static IP address for the Research Service (WebSocket backend). Must be in the same region as your GKE cluster."
     default: ""
-  
-  global.networkSettings.databaseServiceIp:
-    type: string
-    title: "Step 2: Database Service Static IP"
-    description: "Static IP address for the Database Service. Must be in the same region as your GKE cluster."
-    default: ""
-
-  global.networkSettings.embeddingServiceIp:
-    type: string
-    title: "Step 2: Embedding Service Static IP"
-    description: "Static IP address for the Embedding Service. Must be in the same region as your GKE cluster."
-    default: ""
-
-  global.networkSettings.knowledgeAssistantIp:
-    type: string
-    title: "Step 2: Knowledge Assistant Static IP"
-    description: "Static IP address for the Knowledge Assistant frontend. Must be in the same region as your GKE cluster."
-    default: ""
 
   # Storage Configuration (Global)
-  global.storageSettings.modelsBucketName:
-    type: string
-    title: "Step 3: Models Storage Bucket (Global)"
-    description: "GCS bucket name for storing ML models and artifacts"
-    default: ""
-  
   global.storageSettings.docUploadBucketName:
     type: string
     title: "Step 3: Document Upload Bucket (Global)"
@@ -311,46 +291,10 @@ properties:
     default: ""
   
   # Step 4: Service Selection
-  aktus-database-service.enabled:
+  enableProductionMode:
     type: boolean
-    title: "Step 4: Enable Database Service"
-    description: "Enable the database manager service (recommended for full functionality)"
-    default: false
-    
-  aktus-knowledge-assistant-service.enabled:
-    type: boolean
-    title: "Step 4: Enable Knowledge Assistant"
-    description: "Enable the knowledge assistant service for interactive chat (recommended for full functionality)"
-    default: false
-    
-  aktus-inference-service.enabled:
-    type: boolean
-    title: "Step 4: Enable Inference Service"
-    description: "Enable the model inference service (requires GPU resources and Hugging Face key)"
-    default: false
-  
-  aktus-embedding-service.enabled:
-    type: boolean
-    title: "Step 4: Enable Embedding Service"
-    description: "Enable the vector embedding service (requires OpenAI API key)"
-    default: false
-    
-  aktus-research-service.enabled:
-    type: boolean
-    title: "Step 4: Enable Research Service"
-    description: "Enable the research service for advanced analytics"
-    default: false
-    
-  aktus-multimodal-data-ingestion-service.enabled:
-    type: boolean
-    title: "Step 4: Enable Multimodal Data Ingestion"
-    description: "Enable the multimodal data ingestion service for document processing"
-    default: false
-    
-  qdrant-service.enabled:
-    type: boolean
-    title: "Step 4: Enable Qdrant Vector Database"
-    description: "Enable the Qdrant vector database service for vector storage"
+    title: "Step 4: Enable Production Mode"
+    description: "Enable all required services for full Aktus AI Platform functionality (Database, Knowledge Assistant, Inference, Embedding, Research, Data Ingestion, and Vector Database)"
     default: false
 
   # Step 5: API Keys & Secrets
@@ -378,10 +322,7 @@ required:
   - secrets.huggingfaceLoginKey
   - gcpServiceAccountEmail
   - global.networkSettings.researchServiceIp
-  - global.networkSettings.databaseServiceIp
-  - global.networkSettings.embeddingServiceIp
-  - global.networkSettings.knowledgeAssistantIp
-  - global.storageSettings.modelsBucketName
   - global.storageSettings.docUploadBucketName
   - global.storageSettings.docProcessingBucketName
   - global.storageSettings.extractedDataBucketName
+  - enableProductionMode


### PR DESCRIPTION
### Context and Motivation

We are preparing a new release of the Aktus AI Platform (v1.0.8). This update involves:

* Propagating the version bump across Dockerfiles, scripts, README, and all Helm chart metadata.
* Simplifying Helm configuration by replacing individual service enable flags and static IP settings with a single `enableProductionMode` toggle.
* Removing redundant `loadBalancerIP` entries and unused GCS model-volume mounts.
* Introducing a new environment variable (`USE_MINICPM_FOR_FLOWCHART`) for certain services.
* Enhancing the marketplace schema with updated defaults, cluster constraints, and a 14-day trial card.

These changes ensure consistency across our deployment artifacts, reduce configuration complexity for end users, and prepare the platform chart for the 1.0.8 release.

### Detailed Explanation

1. **Version Consistency**

   * Everywhere the old version `1.0.3` appeared (labels, comments, chart versions, default Docker image tags), it’s now replaced with `1.0.8`.
   * Ensures that end-to-end deployment (from Helm charts, UI, and marketplace schema) references a single unified release version.

2. **Helm Chart Simplification**

   * **Single Production Toggle:**

     * In `values.yaml` of the umbrella chart, added `enableProductionMode: false` by default.
     * Removed all per-service `enabled: true/false` flags (`aktus-inference-service.enabled`, `aktus-db-manager.enabled`, etc.).
     * In each subchart dependency stanza (in `chart/aktus-ai-platform/Chart.yaml`), replaced `condition: <service>.enabled` with `condition: enableProductionMode`.
     * This means toggling `enableProductionMode: true` will deploy all core, application, and infrastructure services in one shot.
     * **Trade-off:** Consolidates configuration, but sacrifices per-service granularity. We may reintroduce per-service control in a later patch if needed.
   * **Static IP Cleanup:**

     * Previously, each service (Research, Knowledge Assistant, Database, Embedding) had its own `networkSettings.<service>Ip` in `values.yaml`, used both in `service.yaml` (`loadBalancerIP: ...`) and environment variables.
     * Now, only `networkSettings.researchServiceIp` remains required:

       * Knowledge Assistant WebSocket and API endpoints point at `researchServiceIp`.
       * Database Manager, Embedding, and other internal services assume DNS-based discovery within the cluster (no public LB IP).
     * Removed all `loadBalancerIP` fields from `service.yaml` templates. Kubernetes will assign ephemeral external IPs unless users manually patch later.
     * **Risk:** Users relying on static IPs for individual services must adapt; documentation updated accordingly.
   * **Model Volume Cleanup:**

     * Both Inference and MDI charts previously mounted `models-data` from GCS via a CSI driver.
     * These mounts have been commented out/removed, implying that models should now be baked into container images or fetched another way.
     * The only remaining GCS‐fuse mounts are for `doc-upload`, `doc-processing`, and `extracted-data`.
     * **Future Work:** We might reintroduce a data‐volume pattern for models with a separate bucket or sidecar approach.

3. **Environment Variable Additions**

   * Introduced `USE_MINICPM_FOR_FLOWCHART=true` in:

     * `chart/aktus-ai-platform/charts/aktus-inference/templates/deployment.yaml`
     * `chart/aktus-ai-platform/charts/aktus-multimodal-data-ingestion/templates/deployment.yaml`
   * This toggle likely instructs services to use a MiniCPM model for generating flowcharts.
   * **Complex Logic:** No conditional logic in templates; it’s a simple static env var. If we need dynamic toggling later, we can expose it in `values.yaml`.

4. **Knowledge Assistant URL Adjustments**

   * Changed in `chart/aktus-ai-platform/charts/aktus-knowledge-assistant/templates/deployment.yaml`:

     * `VITE_API_BASE_URL` now points to `http://<researchServiceIp>:8080/db-manager` instead of the old `databaseServiceIp`.
     * `VITE_API_EMBED_URL` now points to `http://<researchServiceIp>:8080/embeddings` instead of `embeddingServiceIp`.
   * This unifies all backend API calls via the Research Service (which presumably proxies or routes appropriately).
   * **Trade-off:** Centralizes traffic through the Research Service. Could introduce a bottleneck if Research Service becomes overloaded.

5. **Marketplace Schema (`schema.yaml`)**

   * Updated `x-google-marketplace.publishedVersion` to `1.0.8`, matching charts.
   * Un-commented and strengthened `clusterConstraints` to specify CPU, memory, and GPU requirements (2 replicas, 1 A100 GPU).
   * Updated all default image properties under `images` to `:1.0.8`.
   * Added a small “14-Day Free Trial” card UI block above the existing video installation guide.
   * Set `applicationName` default to `"aktus-ai-platform-marketplace"` for clarity in marketplace forms.

### Testing

  * Deployed on a GKE dev cluster with `enableProductionMode=true`.
  * Loaded `schema.yaml` in the Google Cloud Marketplace form previewer.
