### PR TITLE
Generalize and simplify deployment documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,26 @@ Deploy Aktus AI Platform on Google Cloud Marketplace with our comprehensive depl
 
 ## 📋 Prerequisites
 
+### Required Resources
 - Google Cloud Project with billing enabled
 - Google Cloud SDK installed
-- `kubectl` installed  
+- `kubectl` installed
 - Project Owner permissions
 - OpenAI API key
 - Hugging Face login token
+
+### Cluster Requirements
+- Minimum 4 nodes
+  - `e2-standard-16` x 3
+  - `a2-highgpu-1g` (NVIDIA Tesla A100 40Gi)
+
+
+### Required GCP Resources
+- 1 External Static IP address
+- 3 GCS Buckets:
+  - Document Upload Bucket
+  - Document Processing Bucket
+  - Extracted Data Bucket
 
 ---
 
@@ -67,7 +81,7 @@ Deploy Aktus AI Platform on Google Cloud Marketplace with our comprehensive depl
 | **1** | [Create_Cluster](https://drive.google.com/file/d/1jN72wLWiD_R-nyb-ry0W6oLpD9LY16Rv/view?usp=sharing) | `30 min` | Cluster + Identity |
 | **2** | [GCSFuse_Cluster](https://drive.google.com/file/d/19wrUxLJXTvxQqUjrmbE3bfO3EHhNuvZh/view?usp=sharing) | `30 min` | Cluster GCS Fuse |
 | **3** | [GCSFuse_Node](https://drive.google.com/file/d/1z2T3Al1JHzTSJB_VwrAz7C1XL636UfQw/view?usp=sharing) | `10 min` | Node GCS Fuse |
-| **4** | [Create_IP_Addresses](https://drive.google.com/file/d/1p-TYGfNnmxeVhxobTVmoXr5i7H9w-OZP/view?usp=sharing) | `5 min` | Static IPs |
+| **4** | [Create_IP_Address](https://drive.google.com/file/d/1p-TYGfNnmxeVhxobTVmoXr5i7H9w-OZP/view?usp=sharing) | `5 min` | Static IPs |
 | **5** | [Create_Buckets](https://drive.google.com/file/d/194XKRYR4rNB7rdlhfhMxtLPWRdEgJKd1/view?usp=sharing) | `6 min` | GCS buckets |
 | **6** | [Deploy](https://drive.google.com/file/d/1Hz256McmAUep-yTbBIa0vW2W_aRTCxUK/view?usp=sharing) | `10 min` | Marketplace deploy |
 | **7** | ⏱️ **Wait 5 minutes** | — | Pod initialization |

--- a/docs/cluster-setup.md
+++ b/docs/cluster-setup.md
@@ -82,6 +82,8 @@ gcloud projects add-iam-policy-binding $PROJECT_ID \
 ```
 
 ### Setup Workload Identity
+
+**NOTE**: The value of `YOUR-APPLICATION-NAME` is the same as the name you chose in Step #1 of the application installation.
 ```bash
 kubectl create namespace $NAMESPACE
 
@@ -89,10 +91,10 @@ export PROJECT_NUMBER=$(gcloud projects describe $PROJECT_ID --format="value(pro
 
 gcloud iam service-accounts add-iam-policy-binding $SERVICE_ACCOUNT_EMAIL \
   --role="roles/iam.workloadIdentityUser" \
-  --member="principal://iam.googleapis.com/projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$PROJECT_ID.svc.id.goog/subject/ns/$NAMESPACE/sa/aktus-ai-platform-marketplace-serviceaccount"
+  --member="principal://iam.googleapis.com/projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$PROJECT_ID.svc.id.goog/subject/ns/$NAMESPACE/sa/<YOUR-APPLICATION-NAME>-serviceaccount"
 
 gcloud projects add-iam-policy-binding $PROJECT_ID \
-  --member="principal://iam.googleapis.com/projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$PROJECT_ID.svc.id.goog/subject/ns/$NAMESPACE/sa/aktus-ai-platform-marketplace-serviceaccount" \
+  --member="principal://iam.googleapis.com/projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$PROJECT_ID.svc.id.goog/subject/ns/$NAMESPACE/sa/<YOUR-APPLICATION-NAME>-serviceaccount" \
   --role="roles/storage.objectUser"
 ```
 

--- a/docs/marketplace-deployment.md
+++ b/docs/marketplace-deployment.md
@@ -35,41 +35,33 @@
 
 | Field                         | Value                                                      |
 | ----------------------------- | ---------------------------------------------------------- |
-| **Application Name**    | `aktus-ai-platform-marketplace`                          |
-| **Namespace**           | `platform`                                               |
-| **Service Account**     | `aktus-platform-sa`                                      |
-| **GCP Service Account** | `aktus-platform-sa@<PROJECT_ID>.iam.gserviceaccount.com` |
+| **Application Name**    | The application name from Step 1 during application installtions, e.g. `aktus-ai-platform-marketplace`.                          |
+| **Namespace**           | The `namespace` from Step 1 of app installtions (`NAMESPACE`), e.g. `platform`.                                               |
+| **Service Account**     | The name of the service account created during app installation (`SERVICE-ACCOUNT-NAME`), e.g.`aktus-platform-sa`.                                     |
+| **GCP Service Account** | `<SERVICE-ACCOUNT-NAME>@<PROJECT_ID>.iam.gserviceaccount.com` |
 | **Enable GCS Access**   | ✅ Checked                                                 |
 
 ### Network Configuration
 
-Enter your static IP addresses from Step 2:
+Enter your static IP address from Step 2:
 
 - **Research Service IP:** `XX.XX.XX.XX`
-- **Database Service IP:** `XX.XX.XX.XX`
-- **Embedding Service IP:** `XX.XX.XX.XX`
-- **Knowledge Assistant IP:** `XX.XX.XX.XX`
 
 ### Storage Configuration
 
 Enter your bucket names from Step 3:
 
-- **Models Bucket:** `bucket-models`
+**NOTE**: GCS bucket name MUST be globally unique.
+
 - **Document Upload Bucket:** `bucket-document-upload`
 - **Processing Bucket:** `bucket-document-processing`
 - **Extracted Data Bucket:** `bucket-extracted-data`
 
 ### Service Selection
 
-Enable all services:
+Enable Production mode:
 
-- ✅ Database Service
-- ✅ Knowledge Assistant
-- ✅ Inference Service
-- ✅ Embedding Service
-- ✅ Research Service
-- ✅ Multimodal Data Ingestion
-- ✅ Qdrant Vector Database
+- ✅ Enable Production Mode
 
 ### API Keys
 
@@ -89,8 +81,8 @@ Enable all services:
 ### Check Deployment Status
 
 ```bash
-kubectl get pods -n aktus-platform
-kubectl get services -n aktus-platform
+kubectl get pods -n <NAMESPACE>
+kubectl get services -n <NAMESPACE>
 ```
 
 ---
@@ -98,7 +90,7 @@ kubectl get services -n aktus-platform
 ## 🌐 Access Services
 
 - **Research Service:** `http://<research-ip>:8080`
-- **Knowledge Assistant:** `http://<knowledge-assistant-ip>:3000`
+- **Knowledge Assistant:** `http://<knowledge-endpoint>:3000`
 
 ---
 
@@ -111,7 +103,7 @@ kubectl get services -n aktus-platform
 ### Monitor Progress
 
 ```bash
-kubectl get pods -n aktus-platform -w
+kubectl get pods -n <NAMESPACE> -w
 ```
 
 ---

--- a/docs/network-configuration.md
+++ b/docs/network-configuration.md
@@ -4,7 +4,7 @@
 ---
 
 ## 🎥 Related Videos
-- **[Create_IP_Addresses](https://drive.google.com/file/d/1p-TYGfNnmxeVhxobTVmoXr5i7H9w-OZP/view?usp=sharing)** `5 min`
+- **[Create_IP_Address](https://drive.google.com/file/d/1p-TYGfNnmxeVhxobTVmoXr5i7H9w-OZP/view?usp=sharing)** `5 min`
 
 ---
 
@@ -23,69 +23,22 @@ export PROJECT_ID="your-project-id"
 export REGION="us-central1"
 ```
 
-### Create Static IP Addresses
+### Create Static IP Address
 ```bash
 # Research Service Static IP
 gcloud compute addresses create aktus-research-service-ip \
   --region=$REGION \
   --project=$PROJECT_ID
-
-# Database Service Static IP
-gcloud compute addresses create aktus-database-service-ip \
-  --region=$REGION \
-  --project=$PROJECT_ID
-
-# Embedding Service Static IP
-gcloud compute addresses create aktus-embedding-service-ip \
-  --region=$REGION \
-  --project=$PROJECT_ID
-
-# Knowledge Assistant Static IP
-gcloud compute addresses create aktus-knowledge-assistant-ip \
-  --region=$REGION \
-  --project=$PROJECT_ID
 ```
 
 ---
 
-## 📍 Get IP Addresses
+## 📍 Get IP Address
 
 ```bash
 export RESEARCH_IP=$(gcloud compute addresses describe aktus-research-service-ip --region=$REGION --format="value(address)")
-export DATABASE_IP=$(gcloud compute addresses describe aktus-database-service-ip --region=$REGION --format="value(address)")
-export EMBEDDING_IP=$(gcloud compute addresses describe aktus-embedding-service-ip --region=$REGION --format="value(address)")
-export KNOWLEDGE_ASSISTANT_IP=$(gcloud compute addresses describe aktus-knowledge-assistant-ip --region=$REGION --format="value(address)")
 
 echo "Research Service IP: $RESEARCH_IP"
-echo "Database Service IP: $DATABASE_IP"
-echo "Embedding Service IP: $EMBEDDING_IP"
-echo "Knowledge Assistant IP: $KNOWLEDGE_ASSISTANT_IP"
-```
-
----
-
-## 🔥 Create Firewall Rules
-
-```bash
-gcloud compute firewall-rules create aktus-research-allow-8080 \
-  --allow tcp:8080 \
-  --source-ranges 0.0.0.0/0 \
-  --project=$PROJECT_ID
-
-gcloud compute firewall-rules create aktus-database-allow-5432 \
-  --allow tcp:5432 \
-  --source-ranges 0.0.0.0/0 \
-  --project=$PROJECT_ID
-
-gcloud compute firewall-rules create aktus-embedding-allow-8000 \
-  --allow tcp:8000 \
-  --source-ranges 0.0.0.0/0 \
-  --project=$PROJECT_ID
-
-gcloud compute firewall-rules create aktus-knowledge-assistant-allow-3000 \
-  --allow tcp:3000 \
-  --source-ranges 0.0.0.0/0 \
-  --project=$PROJECT_ID
 ```
 
 ---
@@ -94,7 +47,6 @@ gcloud compute firewall-rules create aktus-knowledge-assistant-allow-3000 \
 
 ```bash
 gcloud compute addresses list --filter="region:$REGION" --project=$PROJECT_ID
-gcloud compute firewall-rules list --filter="name~aktus" --project=$PROJECT_ID
 ```
 
 ---

--- a/docs/storage-configuration.md
+++ b/docs/storage-configuration.md
@@ -22,7 +22,6 @@
 export PROJECT_ID="your-project-id"
 export REGION="us-central1"
 export BUCKET_SUFFIX=$(date +%Y%m%d-%H%M%S)
-export MODELS_BUCKET="aktus-models-${PROJECT_ID}-${BUCKET_SUFFIX}"
 export DOC_UPLOAD_BUCKET="aktus-doc-upload-${PROJECT_ID}-${BUCKET_SUFFIX}"
 export DOC_PROCESSING_BUCKET="aktus-doc-processing-${PROJECT_ID}-${BUCKET_SUFFIX}"
 export EXTRACTED_DATA_BUCKET="aktus-extracted-data-${PROJECT_ID}-${BUCKET_SUFFIX}"
@@ -30,7 +29,6 @@ export EXTRACTED_DATA_BUCKET="aktus-extracted-data-${PROJECT_ID}-${BUCKET_SUFFIX
 
 ### Create GCS Buckets
 ```bash
-gsutil mb -p $PROJECT_ID -c STANDARD -l $REGION gs://$MODELS_BUCKET
 gsutil mb -p $PROJECT_ID -c STANDARD -l $REGION gs://$DOC_UPLOAD_BUCKET
 gsutil mb -p $PROJECT_ID -c STANDARD -l $REGION gs://$DOC_PROCESSING_BUCKET
 gsutil mb -p $PROJECT_ID -c STANDARD -l $REGION gs://$EXTRACTED_DATA_BUCKET
@@ -43,7 +41,6 @@ gsutil mb -p $PROJECT_ID -c STANDARD -l $REGION gs://$EXTRACTED_DATA_BUCKET
 ```bash
 export SERVICE_ACCOUNT_EMAIL="aktus-ai-platform-sa@$PROJECT_ID.iam.gserviceaccount.com"
 
-gsutil iam ch serviceAccount:$SERVICE_ACCOUNT_EMAIL:objectAdmin gs://$MODELS_BUCKET
 gsutil iam ch serviceAccount:$SERVICE_ACCOUNT_EMAIL:objectAdmin gs://$DOC_UPLOAD_BUCKET
 gsutil iam ch serviceAccount:$SERVICE_ACCOUNT_EMAIL:objectAdmin gs://$DOC_PROCESSING_BUCKET
 gsutil iam ch serviceAccount:$SERVICE_ACCOUNT_EMAIL:objectAdmin gs://$EXTRACTED_DATA_BUCKET
@@ -54,7 +51,6 @@ gsutil iam ch serviceAccount:$SERVICE_ACCOUNT_EMAIL:objectAdmin gs://$EXTRACTED_
 ## 📍 Display Bucket Names
 
 ```bash
-echo "Models Bucket: $MODELS_BUCKET"
 echo "Document Upload Bucket: $DOC_UPLOAD_BUCKET"
 echo "Document Processing Bucket: $DOC_PROCESSING_BUCKET"
 echo "Extracted Data Bucket: $EXTRACTED_DATA_BUCKET"


### PR DESCRIPTION
### Context and Motivation

* Previously, deployment documentation contained hardcoded application names, multiple static IP instructions, and references to a models bucket that no longer exists in our simplified architecture.
* Our deployment workflow has since been updated to require only a single external static IP, remove the models bucket, and parameterize application/service account names for flexibility.
* To reduce confusion and support a variety of installation contexts, we need to generalize instructions, replace hardcoded values with placeholders, and remove obsolete steps.

### Summary of Changes

* **README.md**:

  * Added a new “Required Resources” section, splitting into “Cluster Requirements” and “Required GCP Resources.”
  * Specified cluster sizing (minimum 4 nodes) and external resource requirements (1 static IP, 3 GCS buckets).
  * Renamed the “Create\_IP\_Addresses” reference to singular “Create\_IP\_Address.”
* **docs/cluster-setup.md**:

  * Inserted a note explaining that `YOUR-APPLICATION-NAME` matches Step #1 of application installation.
  * Replaced hardcoded service account subject (`aktus-ai-platform-marketplace-serviceaccount`) with a generic `<YOUR-APPLICATION-NAME>-serviceaccount` placeholder.
* **docs/marketplace-deployment.md**:

  * Updated the deployment configuration table to use placeholders:

    * Application Name → “The application name from Step 1 during application installation.”
    * Namespace, Service Account, GCP Service Account → generic `<SERVICE-ACCOUNT-NAME>@<PROJECT_ID>.iam.gserviceaccount.com`.
  * Changed network configuration instructions to request a single static IP instead of multiple.
  * Added a note that GCS bucket names must be globally unique.
  * Updated “Service Selection” to instruct enabling “Production Mode” rather than toggling individual services.
  * Adjusted `kubectl` commands to reference `<NAMESPACE>` instead of a hardcoded namespace.
  * Changed Knowledge Assistant URL placeholder from `<knowledge-assistant-ip>` to `<knowledge-endpoint>`.
* **docs/network-configuration.md**:

  * Renamed headings from plural (“Static IP Addresses”) to singular (“Static IP Address”).
  * Removed commands for creating database, embedding, and knowledge-assistant static IPs; now only one static IP is created.
  * Deleted the entire “Create Firewall Rules” section, as separate firewall rules are no longer required.
  * Updated “Get IP Addresses” section to “Get IP Address” and removed echoes of multiple IPs.
* **docs/storage-configuration.md**:

  * Removed all references to `MODELS_BUCKET` (creation, IAM assignment, and echo).
  * Left only the three required buckets: Document Upload, Document Processing, and Extracted Data.
  * Updated echo commands to reflect only the three remaining buckets.
